### PR TITLE
Only display event detail buttons as admin

### DIFF
--- a/src/pages/events/[eventId]/index.js
+++ b/src/pages/events/[eventId]/index.js
@@ -196,12 +196,16 @@ const EventInfo = () => {
         </Col>
         <Col>
           <Row>
-            <Styled.Routing onClick={routeToRegisteredVolunteers}>
-              Manage Attendance
-            </Styled.Routing>
-            <Styled.Routing onClick={routeToStats}>
-              View Participation Statistics
-            </Styled.Routing>
+            {user.role === "admin" && (
+              <>
+                <Styled.Routing onClick={routeToRegisteredVolunteers}>
+                  Manage Attendance
+                </Styled.Routing>
+                <Styled.Routing onClick={routeToStats}>
+                  View Participation Statistics
+                </Styled.Routing>
+              </>
+            )}
           </Row>
           <Row>
             <Styled.EventCol2 style={{ "margin-right": "auto" }}>


### PR DESCRIPTION
Fix for event-detail-buttons issue, where the volunteer is still able to manage attendance / see participation stats
