### PR TITLE
set date for checkout time to be check in date if checkout currently null

### DIFF
--- a/src/screens/Events/Admin/Statistics/EditEventStatsForm.jsx
+++ b/src/screens/Events/Admin/Statistics/EditEventStatsForm.jsx
@@ -58,10 +58,7 @@ const EditEventStatsForm = ({ toggle, stat }) => {
       ? editedStat.checkoutTime
       : editedStat.checkinTime;
     editedStat.checkoutTime = new Date(
-      new Date(
-        new Date(checkoutDate) -
-          new Date().getTimezoneOffset() * 60_000
-      )
+      new Date(new Date(checkoutDate) - new Date().getTimezoneOffset() * 60_000)
         .toISOString()
         .slice(0, 11) + values.checkout
     ).toISOString();

--- a/src/screens/Events/Admin/Statistics/EditEventStatsForm.jsx
+++ b/src/screens/Events/Admin/Statistics/EditEventStatsForm.jsx
@@ -46,10 +46,6 @@ const EditEventStatsForm = ({ toggle, stat }) => {
     const editedStat = {
       ...attendance,
     };
-    console.log(values);
-    console.log("________");
-    console.log(editedStat);
-    console.log("________");
     editedStat.checkinTime = new Date(
       new Date(
         new Date(editedStat.checkinTime) -
@@ -58,7 +54,9 @@ const EditEventStatsForm = ({ toggle, stat }) => {
         .toISOString()
         .slice(0, 11) + values.checkin
     ).toISOString();
-    const checkoutDate = editedStat.checkoutTime ? editedStat.checkoutTime : editedStat.checkinTime;
+    const checkoutDate = editedStat.checkoutTime
+      ? editedStat.checkoutTime
+      : editedStat.checkinTime;
     editedStat.checkoutTime = new Date(
       new Date(
         new Date(checkoutDate) -
@@ -68,7 +66,6 @@ const EditEventStatsForm = ({ toggle, stat }) => {
         .slice(0, 11) + values.checkout
     ).toISOString();
     setSubmitting(true);
-    console.log(editedStat);
     updateAttendance(stat._id, editedStat).then((response) => {
       setAttendance(response.data.attendance);
     });

--- a/src/screens/Events/Admin/Statistics/EditEventStatsForm.jsx
+++ b/src/screens/Events/Admin/Statistics/EditEventStatsForm.jsx
@@ -46,6 +46,10 @@ const EditEventStatsForm = ({ toggle, stat }) => {
     const editedStat = {
       ...attendance,
     };
+    console.log(values);
+    console.log("________");
+    console.log(editedStat);
+    console.log("________");
     editedStat.checkinTime = new Date(
       new Date(
         new Date(editedStat.checkinTime) -
@@ -54,15 +58,17 @@ const EditEventStatsForm = ({ toggle, stat }) => {
         .toISOString()
         .slice(0, 11) + values.checkin
     ).toISOString();
+    const checkoutDate = editedStat.checkoutTime ? editedStat.checkoutTime : editedStat.checkinTime;
     editedStat.checkoutTime = new Date(
       new Date(
-        new Date(editedStat.checkoutTime) -
+        new Date(checkoutDate) -
           new Date().getTimezoneOffset() * 60_000
       )
         .toISOString()
         .slice(0, 11) + values.checkout
     ).toISOString();
     setSubmitting(true);
+    console.log(editedStat);
     updateAttendance(stat._id, editedStat).then((response) => {
       setAttendance(response.data.attendance);
     });


### PR DESCRIPTION
### Fix Update Participation Statistics

When updating the checkout time of a volunteer that had not been checked out yet, their checkoutDate was set to null >> 1970.

