### PR TITLE
Delete loading info (#544)

### DIFF
--- a/src/screens/Index/IndexPage.jsx
+++ b/src/screens/Index/IndexPage.jsx
@@ -14,10 +14,6 @@ const IndexPage = () => {
 
   return (
     <>
-      <h1>
-        Welcome {user.firstName} {user.lastName}
-      </h1>
-      <h2>Role: {user.role}</h2>
     </>
   );
 };

--- a/src/screens/Index/IndexPage.jsx
+++ b/src/screens/Index/IndexPage.jsx
@@ -2,6 +2,7 @@ import { useSession } from "next-auth/react";
 import router from "next/router";
 import "normalize.css";
 import { useEffect } from "react";
+import LoadingScreen from "../../components/LoadingScreen";
 
 const IndexPage = () => {
   const {
@@ -12,10 +13,7 @@ const IndexPage = () => {
     router.push("/home");
   });
 
-  return (
-    <>
-    </>
-  );
+  return <LoadingScreen />;
 };
 
 export default IndexPage;


### PR DESCRIPTION
### Delete loading info (#544)

Fixes #544. Deleted the name and role display that flashes on the index page when loading.